### PR TITLE
Refactor inventory grid and item index handling

### DIFF
--- a/Source/AsukaInventory/Private/InventoryManagment/Utils/Inv_InventoryStatics.cpp
+++ b/Source/AsukaInventory/Private/InventoryManagment/Utils/Inv_InventoryStatics.cpp
@@ -174,7 +174,7 @@ UInv_ExternalInventoryComponent* UInv_InventoryStatics::CreateExternalInventoryC
 	{
 		if (IsValid(SourceItem))
 		{
-			UInv_ExternalInventoryComponent::Execute_AddItemToList(ExternalInventoryComponent, SourceItem->GetStaticItemManifestAssetId(), SourceItem->GetDynamicItemFragments());
+			UInv_ExternalInventoryComponent::Execute_AddItemToList(ExternalInventoryComponent, SourceItem->GetStaticItemManifestAssetId(), SourceItem->GetDynamicItemFragments(), SourceItem->GetItemIndex());
 		}
 	}
 

--- a/Source/AsukaInventory/Private/Items/Fragments/Inv_ItemFragment.cpp
+++ b/Source/AsukaInventory/Private/Items/Fragments/Inv_ItemFragment.cpp
@@ -40,7 +40,7 @@ void FInv_LabeledNumberFragment::Assimilate(UInv_CompositeBase* Composite) const
 	FInv_InventoryItemFragmentAbstract::Assimilate(Composite);
 	if (!MatchesWidgetTag(Composite)) return;
 	const UInv_Leaf_LabeledValue* LabeledLeaf = Cast<UInv_Leaf_LabeledValue>(Composite);
-
+	if (!IsValid(LabeledLeaf)) return;
 	LabeledLeaf->SetLabelText(Text_Label, bCollapseLabel);
 
 	FNumberFormattingOptions Options;

--- a/Source/AsukaInventory/Private/Items/Inv_InventoryItem.cpp
+++ b/Source/AsukaInventory/Private/Items/Inv_InventoryItem.cpp
@@ -12,6 +12,7 @@ void UInv_InventoryItem::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& O
 	UObject::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(ThisClass, DynamicItemFragments);
 	DOREPLIFETIME(ThisClass, StaticItemManifestAssetId);
+	DOREPLIFETIME(ThisClass, ItemIndex);
 }
 
 void UInv_InventoryItem::SetDynamicItemFragments(const TArray<TInstancedStruct<FInv_ItemFragment>>& Fragments)

--- a/Source/AsukaInventory/Public/InventoryManagment/Components/Inv_ExternalInventoryComponent.h
+++ b/Source/AsukaInventory/Public/InventoryManagment/Components/Inv_ExternalInventoryComponent.h
@@ -22,6 +22,7 @@ public:
 	TArray<UInv_InventoryItem* > GetInventoryItems() const { return InventoryList.GetAllItems(); }
 	FInventoryFastArrayItemChange& GetItemAddDelegate() { return InventoryList.OnItemAdded; }
 	FInventoryFastArrayItemChange& GetItemRemoveDelegate() { return InventoryList.OnItemRemoved; }
+	FInventoryFastArrayItemChange& GetItemChangedDelegate() { return InventoryList.OnItemChanged; }
 
 	void AddRepSubObj(UObject* SubObj);
 
@@ -30,7 +31,9 @@ public:
 	// IInv_ItemListInterface interface:
 	virtual UInv_InventoryItem* FindFirstItemByType_Implementation(const FGameplayTag& ItemType) const override { return InventoryList.FindFirstItemByType(ItemType); }
 	virtual void RemoveItemFromList_Implementation(UInv_InventoryItem* Item) override;
-	virtual UInv_InventoryItem* AddItemToList_Implementation(const FPrimaryAssetId& StaticItemManifestID, const TArray<TInstancedStruct<FInv_ItemFragment>>& DynamicFragments) override;
+	virtual UInv_InventoryItem* AddItemToList_Implementation(const FPrimaryAssetId& StaticItemManifestID, const TArray<TInstancedStruct<FInv_ItemFragment>>& DynamicFragments, const int32 GridIndex) override;
+	virtual void ChangeItemGridIndex_Implementation(UInv_InventoryItem* Item, const int32 NewGridIndex) override;
+	virtual void MarkItemDirty_Implementation(UInv_InventoryItem* Item) override;
 
 	UFUNCTION(BlueprintCallable, Category = "Inventory")
 	void OpenItemsContainer(APlayerController* PlayerController);
@@ -46,8 +49,6 @@ protected:
 private:
 	UFUNCTION()
 	void OnInventoryMenuToggled(const bool IsOpen);
-	UFUNCTION()
-	void OnInventoryItemGridChange(UInv_InventoryItem* Item, int32 StackCount, EInv_ItemCategory OldGridCategory, EInv_ItemCategory NewGridCategory);
 
 	UPROPERTY(EditAnywhere, Category = "Inventory", Replicated)
 	TArray<FPrimaryAssetId> InitialItemsIDs;

--- a/Source/AsukaInventory/Public/InventoryManagment/FastArray/Inv_FastArray.h
+++ b/Source/AsukaInventory/Public/InventoryManagment/FastArray/Inv_FastArray.h
@@ -48,6 +48,7 @@ public:
 	// FastArraySerializer contract
 	void PreReplicatedRemove(const TArrayView<int32> RemovedIndices, int32 FinalSize);
 	void PostReplicatedAdd(const TArrayView<int32> AddedIndices, int32 FinalSize);
+	void PostReplicatedChange(const TArrayView<int32>& ChangedIndices, int32 FinalSize);
 	// End of FastArraySerializer contract
 
 	bool NetDeltaSerialize(FNetDeltaSerializeInfo& DeltaParams)
@@ -57,14 +58,17 @@ public:
 
 	UInv_InventoryItem* AddEntry(UInv_ItemComponent* ItemComponent);
 	UInv_InventoryItem* AddEntry(UInv_ExternalInventoryComponent* ExternalComponent, const FPrimaryAssetId& StaticItemManifestID,
-		const TArray<TInstancedStruct<FInv_ItemFragment>>& DynamicFragments = {});
+		const TArray<TInstancedStruct<FInv_ItemFragment>>& DynamicFragments = {}, const int32 GridIndex = -1);
 	UInv_InventoryItem* AddEntry(const FPrimaryAssetId& StaticItemManifestID,
-		const TArray<TInstancedStruct<FInv_ItemFragment>>& DynamicFragments = {});
+		const TArray<TInstancedStruct<FInv_ItemFragment>>& DynamicFragments = {}, const int32 GridIndex = -1);
+	bool ChangeEntryGridIndex(UInv_InventoryItem* Item, const int32 NewGridIndex);
+	bool MarkEntryDirty(UInv_InventoryItem* Item);
 
 	void RemoveEntry(UInv_InventoryItem* Item);
 	UInv_InventoryItem* FindFirstItemByType(const FGameplayTag& ItemType) const;
 
 	FInventoryFastArrayItemChange OnItemAdded;
+	FInventoryFastArrayItemChange OnItemChanged;
 	FInventoryFastArrayItemChange OnItemRemoved;
 
 private:
@@ -102,5 +106,9 @@ public:
 	void RemoveItemFromList(UInv_InventoryItem* Item);
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, meta = (AutoCreateRefTerm = "DynamicFragments"), Category = "Interface")
 	UInv_InventoryItem* AddItemToList(const FPrimaryAssetId& StaticItemManifestID,
-		const TArray<TInstancedStruct<FInv_ItemFragment>>& DynamicFragments);
+		const TArray<TInstancedStruct<FInv_ItemFragment>>& DynamicFragments, const int32 GridIndex);
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "Interface")
+	void ChangeItemGridIndex(UInv_InventoryItem* Item, const int32 NewGridIndex);
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "Interface")
+	void MarkItemDirty(UInv_InventoryItem* Item);
 };

--- a/Source/AsukaInventory/Public/Items/Inv_InventoryItem.h
+++ b/Source/AsukaInventory/Public/Items/Inv_InventoryItem.h
@@ -27,6 +27,9 @@ public:
 	const FInv_ItemManifest& GetItemManifest() const;
 	FInv_ItemManifest& GetItemManifestMutable() { return StaticItemManifest.GetMutable<FInv_ItemManifest>();}
 
+	void SetItemIndex(const int32 Index) { ItemIndex = Index; }
+	int32 GetItemIndex() const { return ItemIndex; }
+
 	const TArray<TInstancedStruct<FInv_ItemFragment>>& GetDynamicItemFragments() const { return DynamicItemFragments; }
 
 	bool IsStackable() const;
@@ -56,6 +59,8 @@ private:
 
 	UPROPERTY(meta = (BaseStuct = "/Script/AsukaInventory.Inv_ItemManifest"))
 	FInstancedStruct StaticItemManifest;
+	UPROPERTY(Replicated)
+	int32 ItemIndex{ -1 };
 };
 
 

--- a/Source/AsukaInventory/Public/Widgets/Inventory/Base/Inv_InventoryBase.h
+++ b/Source/AsukaInventory/Public/Widgets/Inventory/Base/Inv_InventoryBase.h
@@ -19,7 +19,7 @@ class ASUKAINVENTORY_API UInv_InventoryBase : public UUserWidget
 	GENERATED_BODY()
 public:
 	virtual FInv_SlotAvailabilityResult HasRoomForItem(UInv_ItemComponent* ItemComponent) const { return  FInv_SlotAvailabilityResult(); }
-	virtual FInv_SlotAvailabilityResult HasRoomForItem(UInv_InventoryItem* Item, const int32 StackAmountOverride = -1,  const EInv_ItemCategory GridCategory = EInv_ItemCategory::None) const { return  FInv_SlotAvailabilityResult(); }
+	virtual FInv_SlotAvailabilityResult HasRoomForItem(UInv_InventoryItem* Item, const int32 StackAmountOverride = -1, const int32 GridIndex = 1, const EInv_ItemCategory GridCategory = EInv_ItemCategory::None) const { return  FInv_SlotAvailabilityResult(); }
 	virtual void OnItemHovered(UInv_InventoryItem* Item) {};
 	virtual void OnItemUnhovered() {};
 	virtual bool HasHoverItem() const { return false; }

--- a/Source/AsukaInventory/Public/Widgets/Inventory/HoverItem/Inv_HoverItem.h
+++ b/Source/AsukaInventory/Public/Widgets/Inventory/HoverItem/Inv_HoverItem.h
@@ -36,9 +36,6 @@ public:
 	void SetInventoryItem(UInv_InventoryItem* Item);
 	FIntPoint GetGridDimensions() const { return GridDimensions; }
 
-	void SetParentGridItemCategory(const EInv_ItemCategory Category) { ParentGridItemCategory = Category; }
-	EInv_ItemCategory GetParentGridItemCategory() const { return ParentGridItemCategory; }
-
 	void SetOwningGrid(UInv_InventoryGrid* Grid);
 	UInv_InventoryGrid* GetOwningGrid() const;
 
@@ -55,6 +52,5 @@ private:
 	TWeakObjectPtr<UInv_InventoryItem> InventoryItem;
 	bool bIsStackable{ false };
 	int32 StackCount {0};
-	EInv_ItemCategory ParentGridItemCategory { EInv_ItemCategory::None};
 	TWeakObjectPtr<UInv_InventoryGrid> OwningGrid;
 };

--- a/Source/AsukaInventory/Public/Widgets/Inventory/Spatial/Inv_LootInventoryGrid.h
+++ b/Source/AsukaInventory/Public/Widgets/Inventory/Spatial/Inv_LootInventoryGrid.h
@@ -20,13 +20,14 @@ public:
 	virtual void AddItem(UInv_InventoryItem* Item) override;
 	virtual void DropHoverItem() override;
 	void SetExternalInventoryComponent(UInv_ExternalInventoryComponent* ExternalInventoryComp);
+
 protected:
 	virtual void OnInventoryMenuToggled(const bool IsOpen) override;
 	virtual bool IsItemCategoryValidForGrid(const EInv_ItemCategory Category) const override { return true; }
-private:
 
-	UFUNCTION()
-	void RemoveItem(UInv_InventoryItem* Item);
+	virtual TScriptInterface<IInv_ItemListInterface> GetGridInventoryInterface() const override;
+
+private:
 	void ClearGrid();
 
 	void RemoveExternalInventoryComponentLinkage();

--- a/Source/AsukaInventory/Public/Widgets/Inventory/Spatial/Inv_SpatialInventory.h
+++ b/Source/AsukaInventory/Public/Widgets/Inventory/Spatial/Inv_SpatialInventory.h
@@ -25,7 +25,7 @@ class ASUKAINVENTORY_API UInv_SpatialInventory : public UInv_InventoryBase
 	GENERATED_BODY()
 public:
 	virtual FInv_SlotAvailabilityResult HasRoomForItem(UInv_ItemComponent* ItemComponent) const override;
-	virtual FInv_SlotAvailabilityResult HasRoomForItem(UInv_InventoryItem* Item, const int32 StackAmountOverride = -1, const EInv_ItemCategory GridCategory = EInv_ItemCategory::None) const override;
+	virtual FInv_SlotAvailabilityResult HasRoomForItem(UInv_InventoryItem* Item, const int32 StackAmountOverride = -1, const int32 GridIndex = 1, const EInv_ItemCategory GridCategory = EInv_ItemCategory::None) const override;
 	virtual void NativeOnInitialized() override;
 	virtual FReply NativeOnMouseButtonDown(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;
 	virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;


### PR DESCRIPTION
This commit refactors inventory management to use item grid indices for more precise item placement and movement. It introduces new methods for changing item grid indices, marking items dirty, and updating stack counts, and removes legacy item category change logic. Inventory grid widgets now respond to item add, remove, and change events, and item index is now replicated for networked gameplay. The changes improve item movement, stacking, and synchronization between grids and inventories.